### PR TITLE
do not allow empty strings on FTP config, and allow to abort process

### DIFF
--- a/newproject.command
+++ b/newproject.command
@@ -38,15 +38,53 @@ fi
 # --------------------
 echo "If you want to configure sFTP now, please enter FTP host, else leave blank"
 read FTP_HOST
-if [[ $FTP_HOST != "" ]]; then
-	echo "FTP user ?"
+if [[ -n "$FTP_HOST" ]]; then
+
+	ABORT_SFTP=false
+
+	echo "FTP user ? (or Q to quit sFTP configuration)"
 	read FTP_USER
+	while [[ -z "$FTP_USER" ]]; do
+	    echo "Please, type your FTP user (or Q to quit sFTP configuration):"
+	    read FTP_USER
+	done
 
-	echo "FTP password ?"
-	read FTP_PASS
+	if [[ $FTP_USER =~ ^[Qq]$ ]]; then
+		ABORT_SFTP=true
+	fi
 
-	echo "FTP remote path ?"
-	read FTP_ROOT
+	if [[ $ABORT_SFTP == false ]]; then
+		echo "FTP password ? (or Q to quit sFTP configuration)"
+		read FTP_PASS
+		while [[ -z "$FTP_PASS" ]]; do
+		    echo "Please, type your FTP password (or Q to quit sFTP configuration):"
+		    read FTP_PASS
+		done
+	fi
+
+	if [[ $FTP_PASS =~ ^[Qq]$ ]]; then
+		ABORT_SFTP=true
+	fi
+
+	if [[ $ABORT_SFTP == false ]]; then
+		echo "FTP remote path ? (or Q to quit sFTP configuration)"
+		read FTP_ROOT
+		while [[ -z "$FTP_ROOT" ]]; do
+		    echo "Please, type your FTP remote path (or Q to quit sFTP configuration):"
+		    read FTP_ROOT
+		done
+	fi
+
+	if [[ $FTP_ROOT =~ ^[Qq]$ ]]; then
+		ABORT_SFTP=true
+	fi
+
+	# If sFTP has been aborted, set $FTP_HOST to null
+	# so FTP files are not created
+	if [[ $ABORT_SFTP == true ]]; then
+		FTP_HOST=''
+	fi
+
 fi
 
 # --------------------


### PR DESCRIPTION
Hi Jeremy,

I modified the sFTP config code so it won't let empty strings in, and also give you the possibility to abort sFTP configuration at any of the steps. If config is aborted, then $FTP_HOST is set to null so the FTP file won't be created.

Also, changed 

```
if [[ $FTP_HOST != "" ]]
```

to

```
if [[ -n "$FTP_HOST" ]] 
```

just because it's shorter and a primary way to check if a var is null (just learnt it today, I must say).

Cheers!
