### PR TITLE
changing WP urls from http to https

### DIFF
--- a/config-sample.cfg
+++ b/config-sample.cfg
@@ -8,14 +8,14 @@
 DIRECTORY="/Applications/MAMP/htdocs/"
 
 # wordpress url must be a zip to download
-WORDPRESS_URL="http://wordpress.org/latest.zip"
+WORDPRESS_URL="https://wordpress.org/latest.zip"
 
 # Theme must be a git repository
 THEME_URL="https://github.com/jeremycastelli/Jelli.git"
 
 # Plugins must be zips to download
 # separate files with a space
-PLUGINS_URL=("http://downloads.wordpress.org/plugin/underconstruction.1.08.zip" "http://downloads.wordpress.org/plugin/contact-form-7.3.3.3.zip")
+PLUGINS_URL=("https://downloads.wordpress.org/plugin/underconstruction.1.08.zip" "https://downloads.wordpress.org/plugin/contact-form-7.3.3.3.zip")
 
 # Path for mysql 
 MYSQL_PATH='/Applications/MAMP/Library/bin/mysql'


### PR DESCRIPTION
It's a bad practice to download [executable] stuff over plain HTTP.